### PR TITLE
Add support for parsing relative urls

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func printIfInScope(scope string, tag Value, schema string, domain string, msg s
 
 	if shouldPrint {
 		strVal := urlObj.String()
+		// Remove the schema if it was added before
 		if msgSchema != "" {
 			strVal = strings.Replace(strVal, msgSchema, "", 1)
 		}

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func printIfInScope(scope string, tag Value, schema string, domain string, msg s
 
 	var msgSchema string
 
-	if !strings.Contains(msg, "http") && !strings.HasPrefix(msg, "/") {
+	if !strings.Contains(msg, "http://") && !strings.Contains(msg, "https://") && !strings.HasPrefix(msg, "/") {
 		msgSchema = "https://"
 	} else {
 		msgSchema = ""


### PR DESCRIPTION
This pull request adds support for parsing relative urls (e.g. a link to "/login") via `url.ResolveReference`.