### PR TITLE
Add support for custom headers via -headers flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	flag.StringVar(&conf.Outdir, "outdir", "", "Directory to save discovered raw HTTP requests")
 	flag.StringVar(&conf.Cookie, "cookie", "", "The value of this will be included as a Cookie header")
 	flag.StringVar(&conf.AuthHeader, "auth", "", "The value of this will be included as a Authorization header")
+	flag.StringVar(&conf.Headers, "headers", "", "Headers to add in all requests. Multiple should be separated by semi-colon, e.g. HeaderOne: ValueOne;HeaderTwo: ValueTwo")
 	flag.StringVar(&conf.Scope, "scope", "subs", "Scope to include:\nstrict = specified domain only\nsubs = specified domain and subdomains\nfuzzy = anything containing the supplied domain\nyolo = everything")
 	flag.BoolVar(&conf.Wayback, "usewayback", false, "Query wayback machine for URLs and add them as seeds for the crawler")
 	flag.BoolVar(&conf.Plain, "plain", false, "Don't use colours or print the banners to allow for easier parsing")
@@ -54,6 +55,14 @@ func main() {
 	flag.BoolVar(&conf.IncludeWayback, "wayback", false, "Include wayback machine entries in output")
 	flag.BoolVar(&conf.IncludeAll, "all", true, "Include everything in output - this is the default, so this option is superfluous")
 	flag.Parse()
+
+	// Verify flags
+	err := config.VerifyFlags(&conf)
+	if err != nil {
+		fmt.Println(err)
+		flag.Usage()
+		os.Exit(1)
+	}
 
 	// if -v is given, just display version number and exit
 	if conf.DisplayVersion {

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -46,6 +46,14 @@ func NewCollector(config *config.Config, au aurora.Aurora, w io.Writer, url stri
 			r.Headers.Set("Authorization", config.AuthHeader)
 		})
 	}
+
+	if config.HeadersMap != nil {
+		c.OnRequest(func(r *colly.Request) {
+			for header, value := range config.HeadersMap {
+				r.Headers.Set(header, value)
+			}
+		})
+	}
 	return &Collector{
 		conf:  config,
 		colly: c,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"errors"
+	"strings"
+)
+
 // Config represents the configuration for both the Collector and cli.
 type Config struct {
 	Url           string
@@ -7,6 +12,8 @@ type Config struct {
 	Outdir        string
 	Cookie        string
 	AuthHeader    string
+	Headers       string
+	HeadersMap    map[string]string
 	Scope         string
 	Version       string
 	Wayback       bool
@@ -28,13 +35,15 @@ type Config struct {
 func NewConfig() Config {
 	var conf Config
 	// default values
-	conf.Version = "beta9" 
+	conf.Version = "beta9"
 	conf.DisplayVersion = false
 	conf.Url = ""
 	conf.Depth = 1
 	conf.Outdir = ""
 	conf.Cookie = ""
 	conf.AuthHeader = ""
+	conf.Headers = ""
+	conf.HeadersMap = nil
 	conf.Scope = "subs"
 	conf.Wayback = false
 	conf.Plain = false
@@ -50,4 +59,29 @@ func NewConfig() Config {
 	conf.IncludeAll = true
 
 	return conf
+}
+
+// VerifyFlags does validation and any manipulation that needs to happen from flags.
+func VerifyFlags(conf *Config) error {
+	if conf.Headers != "" {
+		if !strings.Contains(conf.Headers, ":") {
+			return errors.New("headers flag not formatted properly (no colon to separate header and value)")
+		}
+
+		headers := make(map[string]string)
+		rawHeaders := strings.Split(conf.Headers, ";")
+		for _, header := range rawHeaders {
+			var parts []string
+			if strings.Contains(header, ": ") {
+				parts = strings.Split(header, ": ")
+			} else if strings.Contains(header, ":") {
+				parts = strings.Split(header, ":")
+			} else {
+				continue
+			}
+			headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+		conf.HeadersMap = headers
+	}
+	return nil
 }


### PR DESCRIPTION
It would be nice to add support for custom headers, as some applications
rely on these, such as custom CSRF headers, for each request to pass. I
decided to add a new method to parse/verify flags provided to properly
format the headers in a way we'd need, otherwise we'd need to do this
each time a collector is run, which wouldn't be very efficient. As of
now it only does the header parsing, but it probably can/should be
used for flag validation. One example I noticed is if no arguments
or urls from stdin are provided, the tool just hangs, of which we
could catch with this VerifyFlags method.