### PR TITLE
Fix bug where URLs with "http" or paths were not being crawled

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,14 +111,19 @@ func main() {
 
 	for u := range urls {
 		wg.Add(1)
-		go func(url string) {
+		go func(site string) {
 			defer wg.Done()
-			c := collector.NewCollector(&conf, au, stdout, url)
-			// url set but does not include schema
-			if !strings.Contains(url, "://") && url != "" {
-				url = "http://" + url
+			if !strings.Contains(site, "://") && site != "" {
+				site = "http://" + site
 			}
-			reqsMade, crawlErr = c.Crawl(url)
+			parsedUrl, err := url.Parse(site)
+			if err != nil {
+				writeErrAndFlush(stdout, err.Error(), au)
+				return
+			}
+			c := collector.NewCollector(&conf, au, stdout, parsedUrl.Host)
+			// url set but does not include schema
+			reqsMade, crawlErr = c.Crawl(site)
 
 			// Report errors and flush requests to files as we go
 			if crawlErr != nil {


### PR DESCRIPTION
Hey @hakluke, I noticed the changes you made fixed some aspects, but not all. After some debugging, I noticed that URLs passed from stdin with http prefixes, or any path were not being crawled because that exact url was being passed into colly's `AllowedDomains`. However, that value needs to be a domain name, and not a full URL. My changes will parse the URL and only pass the domain in the `AllowedDomains`