### PR TITLE
One more update to remove colly's AllowedDomains as it's preventing crawls

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -30,7 +30,6 @@ type Collector struct {
 // NewCollector returns an initialized Collector.
 func NewCollector(config *config.Config, au aurora.Aurora, w io.Writer, url string) *Collector {
 	c := colly.NewCollector(
-		colly.AllowedDomains(url),
 		colly.MaxDepth(config.Depth),
 		colly.UserAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"),
 	)
@@ -44,6 +43,14 @@ func NewCollector(config *config.Config, au aurora.Aurora, w io.Writer, url stri
 	if config.AuthHeader != "" {
 		c.OnRequest(func(r *colly.Request) {
 			r.Headers.Set("Authorization", config.AuthHeader)
+		})
+	}
+
+	if config.HeadersMap != nil {
+		c.OnRequest(func(r *colly.Request) {
+			for header, value := range config.HeadersMap {
+				r.Headers.Set(header, value)
+			}
 		})
 	}
 	return &Collector{
@@ -71,7 +78,6 @@ func (c *Collector) Crawl(url string) ([]*http.Request, error) {
 	if url == "" {
 		return []*http.Request{}, errors.New("url was empty")
 	}
-
 	// these will store the discovered assets to avoid duplicates
 	var urls sync.Map
 	var subdomains sync.Map
@@ -123,14 +129,23 @@ func (c *Collector) Crawl(url string) ([]*http.Request, error) {
 		}()
 	}
 
+	basehost, err := parseHostFromURL(c.conf.Url)
+	if err != nil {
+		return reqsMade.Reqs, err
+	}
+
 	// colly
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		c.colly.Visit(url)
+		inScope := c.isInScope(url, basehost)
+		if inScope {
+			c.colly.Visit(url)
+		}
 	}()
 
 	wg.Wait()
+	fmt.Println(len(reqsMade.Reqs))
 	return reqsMade.Reqs, nil
 }
 
@@ -228,19 +243,7 @@ func (c *Collector) recordIfInScope(tag aurora.Value, u string, msg string, reqs
 		}
 	}
 
-	var shouldPrint bool
-
-	switch c.conf.Scope {
-	case "strict":
-		shouldPrint = msgHost == basehost
-	case "fuzzy":
-		shouldPrint = strings.Contains(msgHost, basehost)
-	case "subs":
-		shouldPrint = strings.HasSuffix(msgHost, basehost)
-	default:
-		shouldPrint = true
-	}
-
+	shouldPrint := c.isInScope(msgHost, basehost)
 	if !shouldPrint {
 		return false
 	}
@@ -378,4 +381,20 @@ func getReqFromURL(url string) *http.Request {
 		return nil
 	}
 	return req
+}
+
+// isInScope determines whether a URL is in scope based on the provided scope (returns true/false).
+func (c *Collector) isInScope(msgHost string, basehost string) bool {
+	var inScope bool
+	switch c.conf.Scope {
+	case "strict":
+		inScope = msgHost == basehost
+	case "fuzzy":
+		inScope = strings.Contains(msgHost, basehost)
+	case "subs":
+		inScope = strings.HasSuffix(msgHost, basehost)
+	default:
+		inScope = true
+	}
+	return inScope
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -145,7 +145,6 @@ func (c *Collector) Crawl(url string) ([]*http.Request, error) {
 	}()
 
 	wg.Wait()
-	fmt.Println(len(reqsMade.Reqs))
 	return reqsMade.Reqs, nil
 }
 


### PR DESCRIPTION
Removing AllowedDomains since Colly doesn't seem to support wildcard or fuzzy matching, which is missing crawl results. Updating to a more "homegrown" approach of checking if we should be crawling a domain, then doing it.