### PR TITLE
added -insecure flag to allow ignoring insecure https certificates

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 	flag.BoolVar(&conf.IncludeSitemap, "sitemap", false, "Include sitemap.xml entries in output")
 	flag.BoolVar(&conf.IncludeWayback, "wayback", false, "Include wayback machine entries in output")
 	flag.BoolVar(&conf.IncludeAll, "all", true, "Include everything in output - this is the default, so this option is superfluous")
+    flag.BoolVar(&conf.Insecure, "insecure", false, "Ignore invalid HTTPS certificates")
 	flag.Parse()
 
 	// Verify flags

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -57,7 +57,12 @@ func NewCollector(config *config.Config, au aurora.Aurora, w io.Writer, url stri
             )
         }
         
-
+       // added to ignore tls verification
+        if config.Insecure {
+                c.WithTransport(&http.Transport{
+                    TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+                })
+        }
         // Print "Visiting <url>" for each request made
         //c.OnRequest(func(r *colly.Request) {
         //        fmt.Println("Visiting", r.URL.String())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	IncludeSitemap bool
 	IncludeWayback bool
 	IncludeAll     bool
+    Insecure       bool
 }
 
 // NewConfig returns a Config with default values.
@@ -59,6 +60,7 @@ func NewConfig() Config {
 	conf.IncludeSitemap = false
 	conf.IncludeWayback = false
 	conf.IncludeAll = true
+    conf.Insecure = false
 
 	return conf
 }


### PR DESCRIPTION
Implemented https://github.com/hakluke/hakrawler/issues/38 
Now, using the `-insecure` flag, which is **false** by default, users can allow insecure HTTPS requests, ignoring invalid certificates.