### PR TITLE
Added support for (http) proxy server and command line option -proxy.

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func main() {
 	commandLine := flag.NewFlagSet("", flag.ExitOnError)
 	commandLine.StringVar(&conf.Url, "url", "", "The url that you wish to crawl, e.g. google.com or https://example.com. Schema defaults to http")
 	commandLine.IntVar(&conf.Depth, "depth", 1, "Maximum depth to crawl, the default is 1. Anything above 1 will include URLs from robots, sitemap, waybackurls and the initial crawler as a seed. Higher numbers take longer but yield more results.")
+	commandLine.StringVar(&conf.Proxy, "proxy", "", "The address of proxy server used in crawl, e.g. http://127.0.0.1.8080.")
 	commandLine.StringVar(&conf.Outdir, "outdir", "", "Directory to save discovered raw HTTP requests")
 	commandLine.StringVar(&conf.Cookie, "cookie", "", "The value of this will be included as a Cookie header")
 	commandLine.StringVar(&conf.AuthHeader, "auth", "", "The value of this will be included as a Authorization header")

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -13,6 +13,7 @@ import (
         "sync"
 
         "github.com/gocolly/colly"
+        "github.com/gocolly/colly/proxy"
         "github.com/hakluke/hakrawler/pkg/config"
         sitemap "github.com/oxffaa/gopher-parse-sitemap"
 
@@ -63,6 +64,15 @@ func NewCollector(config *config.Config, au aurora.Aurora, w io.Writer, url stri
             )
         }
         
+        if config.Proxy != "" {
+                rp, err := proxy.RoundRobinProxySwitcher(config.Proxy)
+                if err != nil {
+                        errors.New("Invalid proxy address.")
+                        return nil
+                }
+                c.SetProxyFunc(rp)
+        }
+
        // added to ignore tls verification
         if config.Insecure {
                 c.WithTransport(&http.Transport{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 type Config struct {
 	Url           string
 	Depth         int
+	Proxy         string
 	Outdir        string
 	Cookie        string
 	AuthHeader    string
@@ -41,6 +42,7 @@ func NewConfig() Config {
 	conf.DisplayVersion = false
 	conf.Url = ""
 	conf.Depth = 1
+	conf.Proxy = ""
 	conf.Outdir = ""
 	conf.Cookie = ""
 	conf.AuthHeader = ""


### PR DESCRIPTION
Added support to proxy servers (like Burb). Code simply sets proxy server to colly.

There is another PR open regarding proxy support. The reason of duplicate PR is that the other PR seems to support only socks5-proxies and contains unnecessary whitespace changes.

