### PR TITLE
Trim white space prefix in line of robots.txt

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -346,7 +346,7 @@ func (c *Collector) parseRobots(url string, reqsMade *syncList) {
 
         for _, line := range lines {
                 if re.MatchString(line) {
-                        urlstring := re.ReplaceAllString(line, "")
+                        urlstring := strings.TrimLeft(re.ReplaceAllString(line, ""), " ")
                         if c.conf.IncludeRobots || c.conf.IncludeAll {
                                 _ = c.recordIfInScope(c.au.BrightMagenta("[robots]"), url, url+urlstring, reqsMade)
                         }


### PR DESCRIPTION
Run this command, `go run . -url google.com -robots -plain > results.txt`,
can not found `/m/finance` in results, but it's in `https://www.google.com/robots.txt`.

This is because some lines in robots.txt have more than one white space,
function `recordIfInScope` parse the url and throw an error, so it' not in the result.

Trim it in function `parseRobots` will fix this bug.