### PR TITLE
add flag for raw output without prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can now run `~/go/bin/hakrawler`. If you'd like to just run `hakrawler` with
     	Custom headers separated by semi-colon. E.g. -h "Cookie: foo=bar;Authorization: token"
   -insecure
     	Disable TLS verification.
+  -r  
+      Raw output without URL type prefix.
   -t int
     	Number of threads to utilise. (default 8)
 ```


### PR DESCRIPTION
This adds a command line flag so that the link "type" (for lack of a better word...) isn't printed.

With the new shift towards unix philosophy I'm not sure if you'll take that or prefer that we pipe into `awk` but that was easy enough to try a PR. :)