### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/cicd-to-dockerhub.yml
+++ b/.github/workflows/cicd-to-dockerhub.yml
@@ -1,0 +1,36 @@
+name: ci-to-dockerhub
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hakrawler:latest
+          
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Image: golang:1.16.7-alpine3.14
+FROM golang@sha256:7e31a85c5b182e446c9e0e6fba57c522902f281a6a5a6cbd25afa17ac48a6b85 as build
+RUN GO111MODULE=on go get -v github.com/hakluke/hakrawler
+
+# Image: alpine:3.14.1
+FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa2936653258c
+RUN apk -U upgrade --no-cache
+COPY --from=build /go/bin/hakrawler /usr/local/bin/hakrawler
+
+ENTRYPOINT ["hakrawler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,10 @@ FROM alpine@sha256:be9bdc0ef8e96dbc428dc189b31e2e3b05523d96d12ed627c37aa29366532
 RUN apk -U upgrade --no-cache
 COPY --from=build /go/bin/hakrawler /usr/local/bin/hakrawler
 
+RUN adduser \
+    --gecos "" \
+    --disabled-password \
+    hakrawler
+
+USER hakrawler
 ENTRYPOINT ["hakrawler"]


### PR DESCRIPTION
This PR adds a Dockerfile to Hakrawler. Assuming you have Docker on your local system you can simply build the image and run it from the directory of Hakrawler:

`docker build . --tag hakluke/hakrawler`

Once built you can run the tool and check the help prompt works:
`docker run --rm -i hakluke/hakrawler -h`

As an example crawl:
`echo https://google.com | docker run --rm -i hakluke/hakrawler -subs`

EDIT: We also have a workflow with a CICD pipeline to DockerHub. All you need to do is to add the DOCKER_HUB_USERNAME and DOCKER_HUB_ACCESS_TOKEN secrets to the repository and all pushes/merges to the master branch will automatically push an image to DockerHub. This way a user won't have the need to locally build an image and will be able to simply use `docker run --rm -i hakluke/hakrawler -h` directly, for example.