### PR TITLE
Some small changes

### DIFF
--- a/hakrawler.go
+++ b/hakrawler.go
@@ -28,7 +28,7 @@ func main() {
 	insecure := flag.Bool("insecure", false, "Disable TLS verification.")
 	subsInScope := flag.Bool("subs", false, "Include subdomains for crawling.")
 	showSource := flag.Bool("s", false, "Show the source of URL based on where it was found (href, form, script, etc.)")
-	rawHeaders := flag.String(("h"), "", "Custom headers separated by semi-colon. E.g. -h \"Cookie: foo=bar\" ")
+	rawHeaders := flag.String(("h"), "", "Custom headers separated by two semi-colons. E.g. -h \"Cookie: foo=bar\" ")
 	unique := flag.Bool(("u"), false, "Show only unique urls")
 
 	flag.Parse()

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -61,6 +61,7 @@ func main() {
 
 			// Instantiate default collector
 			c := colly.NewCollector(
+                // default user agent header
 				colly.UserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"),
 				// limit crawling to the domain of the specified URL
 				colly.AllowedDomains(hostname),

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -61,6 +61,7 @@ func main() {
 
 			// Instantiate default collector
 			c := colly.NewCollector(
+				colly.UserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"),
 				// limit crawling to the domain of the specified URL
 				colly.AllowedDomains(hostname),
 				// set MaxDepth to the specified depth
@@ -144,13 +145,13 @@ func parseHeaders(rawHeaders string) error {
 		}
 
 		headers = make(map[string]string)
-		rawHeaders := strings.Split(rawHeaders, ";")
+		rawHeaders := strings.Split(rawHeaders, ";;")
 		for _, header := range rawHeaders {
 			var parts []string
 			if strings.Contains(header, ": ") {
-				parts = strings.Split(header, ": ")
+				parts = strings.SplitN(header, ": ", 2)
 			} else if strings.Contains(header, ":") {
-				parts = strings.Split(header, ":")
+				parts = strings.SplitN(header, ":", 2)
 			} else {
 				continue
 			}


### PR DESCRIPTION
This PR tries to resolve few problems:
- Some WAFs reject requests without default UserAgent;
- Splitting header's key-value sometimes incorrect, for example when Referer header used;
- Temporary solution for splitting several headers by two semicolons, because some headers can contain semi-colon (better is to use curl way how to handle this), like UserAgent;

Thanks, Yuriy.
