### PR TITLE
Added -proxy and -timeout flags

### DIFF
--- a/hakrawler.go
+++ b/hakrawler.go
@@ -123,11 +123,6 @@ func main() {
 				})
 			}
 
-			// Skip TLS verification if -insecure flag is present
-			c.WithTransport(&http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: *insecure},
-			})
-
 			if *proxy != "" {
 				// Skip TLS verification for proxy
 				c.WithTransport(&http.Transport{
@@ -135,6 +130,7 @@ func main() {
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: *insecure},
 				})
 			} else {
+				// Skip TLS verification if -insecure flag is present
 				c.WithTransport(&http.Transport{
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: *insecure},
 				})

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -147,7 +147,6 @@ func main() {
 				c.Wait()
 			} else {
 				timer := make(chan int, 1)
-
 				go func() {
 					// Start scraping
 					c.Visit(url)
@@ -160,8 +159,9 @@ func main() {
 				case _ = <-timer:
 					continue
 				case <-time.After(time.Duration(*timeout) * time.Second):
+					close(timer)
 					if *showSource {
-						results <- "[timeout] " + url
+						log.Println("[timeout]", url)
 					}
 				}
 			}
@@ -228,6 +228,11 @@ func printResult(link string, sourceName string, showSource bool, results chan s
 		if showSource {
 			result = "[" + sourceName + "] " + result
 		}
+		defer func() {
+			if err := recover(); err != nil {
+				// nop dont care
+			}
+		}()
 		results <- result
 	}
 }

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -32,13 +32,12 @@ func main() {
 	showSource := flag.Bool("s", false, "Show the source of URL based on where it was found (href, form, script, etc.)")
 	rawHeaders := flag.String(("h"), "", "Custom headers separated by two semi-colons. E.g. -h \"Cookie: foo=bar;;Referer: http://example.com/\" ")
 	unique := flag.Bool(("u"), false, "Show only unique urls")
-	proxy := flag.String(("proxy"), "", "Proxy URL, example: -proxy http://127.0.0.1:8080")
+	proxy := flag.String(("proxy"), "", "Proxy URL. Example: -proxy http://127.0.0.1:8080")
 
 	flag.Parse()
 
 	if *proxy != "" {
 		os.Setenv("PROXY", *proxy)
-		*insecure = true
 	}
 	proxyURL, _ := url.Parse(os.Getenv("PROXY"))
 
@@ -126,7 +125,7 @@ func main() {
 			}
 
 			if *proxy != "" {
-				// Skip TLS verification for proxy
+				// Skip TLS verification for proxy, if -insecure specified
 				c.WithTransport(&http.Transport{
 					Proxy:           http.ProxyURL(proxyURL),
 					TLSClientConfig: &tls.Config{InsecureSkipVerify: *insecure},


### PR DESCRIPTION
`-proxy` turns off TLS verification, and is meant for debugging.
`-timeout` sets a timeout for crawling each URL from stdin, by default there is no timeout