### PR TITLE
Add `-i` flag (crawl inside path) and display an error on stderr if improper URLs are being given

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hakrawler
 
-Fast golang web crawler for gathering URLs and JavaSript file locations. This is basically a simple implementation of the awesome Gocolly library.
+Fast golang web crawler for gathering URLs and JavaScript file locations. This is basically a simple implementation of the awesome Gocolly library.
 
 ## Example usages
 
@@ -55,7 +55,7 @@ Then run this command to download + compile hakrawler:
 go install github.com/hakluke/hakrawler@latest
 ```
 
-You can now run `~/go/bin/hakrawler`. If you'd like to just run `hakrawler` without the full path, you'll need to `export PATH="/go/bin/:$PATH"`. You can also add this line to your `~/.bashrc` file if you'd like this to persist.
+You can now run `~/go/bin/hakrawler`. If you'd like to just run `hakrawler` without the full path, you'll need to `export PATH="~/go/bin/:$PATH"`. You can also add this line to your `~/.bashrc` file if you'd like this to persist.
 
 ### Docker Install (from dockerhub)
 
@@ -72,6 +72,11 @@ git clone https://github.com/hakluke/hakrawler
 cd hakrawler
 docker build -t hakluke/hakrawler .
 docker run --rm -i hakluke/hakrawler --help
+```
+### Kali Linux: Using apt
+
+```sh
+sudo apt install hakrawler
 ```
 
 Then, to run hakrawler:

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -72,7 +72,7 @@ func main() {
 			hostname, err := extractHostname(url)
 			if err != nil {
 				log.Println("Error parsing URL:", err)
-				return
+				continue
 			}
 
 			allowed_domains := []string{hostname}
@@ -226,9 +226,10 @@ func parseHeaders(rawHeaders string) error {
 // extractHostname() extracts the hostname from a URL and returns it
 func extractHostname(urlString string) (string, error) {
 	u, err := url.Parse(urlString)
-	if err != nil {
-		return "", err
+	if err != nil || !u.IsAbs() {
+		return "", errors.New("Input must be a valid absolute URL")
 	}
+
 	return u.Hostname(), nil
 }
 

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -30,6 +30,7 @@ var headers map[string]string
 var sm sync.Map
 
 func main() {
+	inside := flag.Bool("i", false, "Only crawl inside path")
 	threads := flag.Int("t", 8, "Number of threads to utilise.")
 	depth := flag.Int("d", 2, "Depth to crawl.")
 	maxSize := flag.Int("size", -1, "Page size limit, in KB.")
@@ -114,8 +115,12 @@ func main() {
 			// Print every href found, and visit it
 			c.OnHTML("a[href]", func(e *colly.HTMLElement) {
 				link := e.Attr("href")
-				printResult(link, "href", *showSource, *showJson, results, e)
-				e.Request.Visit(link)
+				abs_link := e.Request.AbsoluteURL(link)
+				if strings.Contains(abs_link, url) || !*inside {
+
+					printResult(link, "href", *showSource, *showJson, results, e)
+					e.Request.Visit(link)
+				}
 			})
 
 			// find and print all the JavaScript files


### PR DESCRIPTION
`url.Parse` does not return an error most of the time because it treats random strings as relative URLs. 