### PR TITLE
Show at which link the URL is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Usage of hakrawler:
   -proxy string
     	Proxy URL. E.g. -proxy http://127.0.0.1:8080
   -s	Show the source of URL based on where it was found. E.g. href, form, script, etc.
+  -w    Show at which link the URL is found.
   -size int
     	Page size limit, in KB. (default -1)
   -subs

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -22,6 +22,7 @@ import (
 type Result struct {
 	Source string
 	URL    string
+	Where  string
 }
 
 var headers map[string]string
@@ -37,6 +38,7 @@ func main() {
 	subsInScope := flag.Bool("subs", false, "Include subdomains for crawling.")
 	showJson := flag.Bool("json", false, "Output as JSON.")
 	showSource := flag.Bool("s", false, "Show the source of URL based on where it was found. E.g. href, form, script, etc.")
+	showWhere := flag.Bool("w", false, "Show at which link the URL is found.")
 	rawHeaders := flag.String(("h"), "", "Custom headers separated by two semi-colons. E.g. -h \"Cookie: foo=bar;;Referer: http://example.com/\" ")
 	unique := flag.Bool(("u"), false, "Show only unique urls.")
 	proxy := flag.String(("proxy"), "", "Proxy URL. E.g. -proxy http://127.0.0.1:8080")
@@ -114,18 +116,18 @@ func main() {
 			// Print every href found, and visit it
 			c.OnHTML("a[href]", func(e *colly.HTMLElement) {
 				link := e.Attr("href")
-				printResult(link, "href", *showSource, *showJson, results, e)
+				printResult(link, "href", *showSource, *showWhere, *showJson, results, e)
 				e.Request.Visit(link)
 			})
 
 			// find and print all the JavaScript files
 			c.OnHTML("script[src]", func(e *colly.HTMLElement) {
-				printResult(e.Attr("src"), "script", *showSource, *showJson, results, e)
+				printResult(e.Attr("src"), "script", *showSource, *showWhere, *showJson, results, e)
 			})
 
 			// find and print all the form action URLs
 			c.OnHTML("form[action]", func(e *colly.HTMLElement) {
-				printResult(e.Attr("action"), "form", *showSource, *showJson, results, e)
+				printResult(e.Attr("action"), "form", *showSource, *showWhere, *showJson, results, e)
 			})
 
 			// add the custom headers
@@ -233,17 +235,27 @@ func extractHostname(urlString string) (string, error) {
 }
 
 // print result constructs output lines and sends them to the results chan
-func printResult(link string, sourceName string, showSource bool, showJson bool, results chan string, e *colly.HTMLElement) {
+func printResult(link string, sourceName string, showSource bool, showWhere bool, showJson bool, results chan string, e *colly.HTMLElement) {
 	result := e.Request.AbsoluteURL(link)
+	whereURL := e.Request.URL.String()
 	if result != "" {
 		if showJson {
+		    where := ""
+		    if showWhere {
+			    where = whereURL
+			}
 			bytes, _ := json.Marshal(Result{
 				Source: sourceName,
 				URL:    result,
+				Where:  where,
 			})
 			result = string(bytes)
 		} else if showSource {
-			result = "[" + sourceName + "] " + result
+		    whereResult := ""
+			if showWhere {
+			    whereResult = "[" + whereURL + "] "
+			}
+			result = whereResult + "[" + sourceName + "] " + result
 		}
 		// If timeout occurs before goroutines are finished, recover from panic that may occur when attempting writing to results to closed results channel
 		defer func() {

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -261,9 +261,9 @@ func printResult(link string, sourceName string, showSource bool, showWhere bool
 			result = "[" + sourceName + "] " + result
 		}
 
-        if showWhere && !showJson {
-            result = "[" + whereURL + "] " + result
-        }
+		if showWhere && !showJson {
+			result = "[" + whereURL + "] " + result
+		}
 
 		// If timeout occurs before goroutines are finished, recover from panic that may occur when attempting writing to results to closed results channel
 		defer func() {

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -258,12 +258,13 @@ func printResult(link string, sourceName string, showSource bool, showWhere bool
 			})
 			result = string(bytes)
 		} else if showSource {
-		    whereResult := ""
-			if showWhere {
-			    whereResult = "[" + whereURL + "] "
-			}
-			result = whereResult + "[" + sourceName + "] " + result
+			result = "[" + sourceName + "] " + result
 		}
+
+        if showWhere && !showJson {
+            result = "[" + whereURL + "] " + result
+        }
+
 		// If timeout occurs before goroutines are finished, recover from panic that may occur when attempting writing to results to closed results channel
 		defer func() {
 			if err := recover(); err != nil {


### PR DESCRIPTION
When more than one depth is used ("-d 2,3,4,...,n"), the information from where the found URLs are not available. A feature that provides data on where the found URLs are.