### PR TITLE
Added a condition to separate GET parameters links

### DIFF
--- a/hakrawler.go
+++ b/hakrawler.go
@@ -126,15 +126,19 @@ func main() {
 				link := e.Attr("href")
 				abs_link := e.Request.AbsoluteURL(link)
 				if strings.Contains(abs_link, url) || !*inside {
-
-					printResult(link, "href", *showSource, *showWhere, *showJson, results, e)
+					if strings.Contains(link, "?"){
+						printResult(link, "dyn_url", *showSource, *showWhere, *showJson, results, e)
+					} else {
+						printResult(link, "url", *showSource, *showWhere, *showJson, results, e)
+					}
+					// printResult(link, "url", *showSource, *showWhere, *showJson, results, e)
 					e.Request.Visit(link)
 				}
 			})
 
 			// find and print all the JavaScript files
 			c.OnHTML("script[src]", func(e *colly.HTMLElement) {
-				printResult(e.Attr("src"), "script", *showSource, *showWhere, *showJson, results, e)
+				printResult(e.Attr("src"), "javascript", *showSource, *showWhere, *showJson, results, e)
 			})
 
 			// find and print all the form action URLs

--- a/hakrawler.go
+++ b/hakrawler.go
@@ -128,6 +128,8 @@ func main() {
 				if strings.Contains(abs_link, url) || !*inside {
 					if strings.Contains(link, "?"){
 						printResult(link, "dyn_url", *showSource, *showWhere, *showJson, results, e)
+					} else if strings.Contains(link, ".js"){
+						printResult(link, "javascript", *showSource, *showWhere, *showJson, results, e)
 					} else {
 						printResult(link, "url", *showSource, *showWhere, *showJson, results, e)
 					}


### PR DESCRIPTION
Hi Hakluke,

This pull request aims to add a condition to help separating the links with GET parameters and normal URL links in the result.
I added a small condition to support separating links with GET parameters and normal URL links in the code.
I also adjusted the attribute tags to make it easier to understand, however, you can change the attribute tags back to the original version in case you think they are not suitable.

Best regards,
Minh